### PR TITLE
fix(extensions.json): 修复volar报错

### DIFF
--- a/vite-vue3-ts-pinia/.vscode/extensions.json
+++ b/vite-vue3-ts-pinia/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-    "recommendations": ["johnsoncodehk.volar"]
+    "recommendations": ["vue.volar"]
 }

--- a/vite-vue3-ts-pinia/.vscode/extensions.json
+++ b/vite-vue3-ts-pinia/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-    "recommendations": ["vue.volar"]
+    "recommendations": ["vue.volar" ]
 }


### PR DESCRIPTION
volar官方在 2022年5月13号的更新中标识符改名了，现在叫 vue.volar。否则vscode会报错The 1 extension(s) below, in workspace recommendations have issues: johnsoncodehk.volar (not found in marketplace)

![image](https://user-images.githubusercontent.com/66819060/200724020-2a88d42c-6156-4f85-9d43-cd7aa775248b.png)

